### PR TITLE
fix(k8s): correct typo in consumer deployment and simplify logging st…

### DIFF
--- a/k8s/06-consumer.yml
+++ b/k8s/06-consumer.yml
@@ -51,7 +51,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: postgres-secret # 引用我们之前创建的Secret
-              key: POSTG-RES_PASSWORD
+              key: POSTGRES_PASSWORD
 
         # Kafka 连接信息
         - name: KAFKA_BOOTSTRAP_SERVERS

--- a/k8s/filebeat-values.yml
+++ b/k8s/filebeat-values.yml
@@ -29,9 +29,9 @@ filebeatConfig:
             multiline.negate: false
             multiline.match: after
             # 将日志解析为JSON，并放置在json键下
-            json.keys_under_root: true
-            json.add_error_key: true
-            json.message_key: log
+            # json.keys_under_root: true
+            # json.add_error_key: true
+            # json.message_key: log
 
     # ======================= Filebeat outputs ===============================
     # 配置Filebeat将收集到的日志发送到哪里

--- a/k8s/logstash-values.yml
+++ b/k8s/logstash-values.yml
@@ -1,40 +1,41 @@
-# 定义Logstash的处理管道
-logstashPipeline:
-  # 'pipeline.yml' 是Logstash的主配置文件
-  pipeline.yml: |
-    - pipeline.id: main
-      path.config: "/usr/share/logstash/pipeline/logstash.conf"
+# k8s/logstash-values.yml (最终、最简化版本)
 
-# 'logstash.conf' 定义了输入、过滤和输出
+# -------------------------------------------------------------
+# 1. 为内部监控指定正确的Elasticsearch地址 (保持不变)
+# -------------------------------------------------------------
+elasticsearch:
+  hosts:
+    - http://elasticsearch-master.my-fastapi-stack.svc.cluster.local:9200
+
+# -------------------------------------------------------------
+# 2. 直接在 logstashConfig 中定义主配置文件内容
+# 这是Helm Chart最推荐的方式，它会自动处理挂载和路径问题
+# -------------------------------------------------------------
 logstashConfig:
+  # 'logstash.conf' 是一个Helm Chart期望的key
   logstash.conf: |
     # --- 输入阶段 ---
-    # 监听来自Filebeat的输入
     input {
       beats {
         port => 5044
       }
     }
 
-    # --- 过滤阶段 ---
-    # 我们的日志已经是JSON格式了，所以过滤非常简单
-    filter {
-      # 将'message'字段解析为JSON
-      json {
-        source => "message"
-      }
-      # （可选）可以添加其他过滤器，比如用grok解析非JSON日志，
-      # 或者用mutate过滤器移除不需要的字段
-    }
-
     # --- 输出阶段 ---
-    # 将处理好的日志发送到Elasticsearch
     output {
       elasticsearch {
-        # 这里是你的Elasticsearch Service在K8s中的地址
-        # 默认的ES Helm Chart会创建一个名为'elasticsearch-master'的服务
         hosts => ["http://elasticsearch-master.my-fastapi-stack.svc.cluster.local:9200"]
-        # 定义索引的名称，可以按天分片
         index => "fastapi-logs-%{+YYYY.MM.dd}"
       }
     }
+    
+service:
+  # 服务名称将是 "logstash"
+  name: logstash
+  type: ClusterIP
+  # 定义beats端口，这是Filebeat需要连接的端口
+  ports:
+    - name: beats
+      port: 5044
+      protocol: TCP
+      targetPort: 5044

--- a/k8s/prometheus-values.yml
+++ b/k8s/prometheus-values.yml
@@ -1,0 +1,2 @@
+prometheus-node-exporter:
+  enabled: false


### PR DESCRIPTION
…ack configuration

- Corrects a typo in the `POSTGRES_PASSWORD` secret key reference in `06-consumer.yml`.
- Simplifies the `logstash-values.yml` to define the pipeline directly and expose the Beats port via a service, removing unnecessary complexity.
- Comments out unused JSON parsing settings in `filebeat-values.yml`.
- Adds `prometheus-values.yml` to disable the node-exporter.